### PR TITLE
Add barcode (0x806) attribute to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,41 +24,40 @@ And try the tool by typing:
 
 By default, the tool will look for a tape device in `/dev/nst0`, or what is pointed to by the `TAPE` environment variable. To specify another device, use the `-d` option.
 
-## :mag: Output example
+## :mag: Partial output example
 ```
 Drive information:
-   Vendor  : HP
-   Model   : Ultrium 2-SCSI
-   Firmware: F63D
+   Vendor  : TANDBERG
+   Model   : LTO-6 HH
+   Firmware: 3579
 Medium information:
   Cartridge Type: 0x00 - Data cartridge
-  Medium format : 0x42 - LTO-2
-  Formatted as  : 0x42 - LTO-2
+  Medium format : 0x5a - LTO-6
+  Formatted as  : 0x5a - LTO-6
   Assign. Org.  : LTO-CVE
-  Manufacturer  : IMATION
-  Serial No     : 0E00776390
-  Manuf. Date   : 2011-12-07 (roughly 9.4 years ago)
-  Tape length   : 609 meters
+  Manufacturer  : HPE
+  Serial No     : F26VYYRDEP
+  Barcode No    : FJK676L6
+  Manuf. Date   : 2022-07-25 (roughly 2.7 years ago)
+  Tape length   : 846 meters
   Tape width    : 12.7 mm
-  MAM Capacity  : 4096 bytes (1014 bytes remaining)
+  MAM Capacity  : 16384 bytes
 Format specs:
-   Capacity  :   200 GB native   -   400 GB compressed with a 2:1 ratio
-   R/W Speed :    40 MB/s native -    80 MB/s compressed
-   Partitions:     1 max partitions supported
-   Phy. specs: 4 bands/tape, 16 wraps/band, 8 tracks/wrap, 512 total tracks
-   Duration  : 1h23 to fill tape with 64 end-to-end passes (78 seconds/pass)
+   Capacity  :  2500 GB native   -  6250 GB compressed with a 2.5:1 ratio
+   R/W Speed :   160 MB/s native -   400 MB/s compressed
+   Partitions:     4 max partitions supported
+   Phy. specs: 4 bands/tape, 34 wraps/band, 16 tracks/wrap, 2176 total tracks
+   Duration  : 4h20 to fill tape with 136 end-to-end passes (115 seconds/pass)
 Usage information:
-  Partition space free  : 96% (193746/200448 MiB, 189/195 GiB, 0.18/0.19 TiB)
-  Cartridge load count  : 13
-  Data written - alltime:        81983 MiB (    80.06 GiB,   0.08 TiB, 0.41 FVE)
-  Data read    - alltime:        20674 MiB (    20.19 GiB,   0.02 TiB, 0.10 FVE)
-  Data written - session:            0 MiB (     0.00 GiB,   0.00 TiB, 0.00 FVE)
-  Data read    - session:          139 MiB (     0.14 GiB,   0.00 TiB, 0.00 FVE)
+  Data written - alltime:            0 MiB (     0.00 GiB,   0.00 TiB)
+  Data read    - alltime:            0 MiB (     0.00 GiB,   0.00 TiB)
+  Data written - session:            0 MiB (     0.00 GiB,   0.00 TiB)
+  Data read    - session:            0 MiB (     0.00 GiB,   0.00 TiB)
 Previous sessions:
-  Session N-0: Used in a device of vendor HP (serial HU10625W0T)
-  Session N-1: Used in a device of vendor HP (serial HU10625W0T)
-  Session N-2: Used in a device of vendor HP (serial HUP9B067QF)
-  Session N-3: Used in a device of vendor HP (serial HUP9B067QF)
+  Session N-0: Used in a device of vendor HP (serial XXXXXXXXXX)
+  Session N-1: Used in a device of vendor HP
+  Session N-2: Used in a device of vendor HP
+  Session N-3: Used in a device of vendor HP
 ```
 
 ## :gem: Build-time dependencies

--- a/cm.go
+++ b/cm.go
@@ -175,6 +175,9 @@ func (cm *Cm) String() string {
 	if cm.SerialNo.IsValid {
 		s += fmt.Sprintf("  Serial No     : %s\n", cm.SerialNo.DataStr)
 	}
+	if cm.Barcode.IsValid {
+		s += fmt.Sprintf("  Barcode No    : %s\n", cm.Barcode.DataStr)
+	}
 	if cm.ManufactureDate.IsValid {
 		if len(cm.ManufactureDate.DataStr) == 8 {
 			// YYYYMMDD

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module speed47.net/cminfo
 
-go 1.16
+go 1.23
 
 require (
-	github.com/HewlettPackard/structex v1.0.2
+	github.com/HewlettPackard/structex v1.0.4
 	github.com/benmcclelland/mtio v0.0.0-20170506231306-f929531fb4fe
 	github.com/benmcclelland/sgio v0.0.0-20180629175614-f710aebf64c1
-	github.com/jessevdk/go-flags v1.5.0
+	github.com/jessevdk/go-flags v1.6.1
 )
+
+require golang.org/x/sys v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
-github.com/HewlettPackard/structex v1.0.2 h1:p2EH/p6zvUd5fSa0onudAUvLWdKsvQSRP0jGKeblA5E=
-github.com/HewlettPackard/structex v1.0.2/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
+github.com/HewlettPackard/structex v1.0.4 h1:RVTdN5FWhDWr1IkjllU8wxuLjISo4gr6u5ryZpzyHcA=
+github.com/HewlettPackard/structex v1.0.4/go.mod h1:3frC4RY/cPsP/4+N8rkxsNAGlQwHV+zDC7qvrN+N+rE=
 github.com/benmcclelland/mtio v0.0.0-20170506231306-f929531fb4fe h1:f+PTGRJrCYSquf31olVAWIqyJwx42eBzVH4D3igzgSk=
 github.com/benmcclelland/mtio v0.0.0-20170506231306-f929531fb4fe/go.mod h1:XyVqnMjuqI1qOvgei81EgX68tV7BjN9JlluJPsjArs0=
 github.com/benmcclelland/sgio v0.0.0-20180629175614-f710aebf64c1 h1:f1AIRyf6d21xBd1DirrIa6fk41O3LB0WvVuVqhPN4co=
 github.com/benmcclelland/sgio v0.0.0-20180629175614-f710aebf64c1/go.mod h1:WdrapyVn/Aduwwf/OMW6sEtk9+7BSoMst1kGrx4E4xE=
-github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
-github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
+github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
This PR exposes in the text output the barcode 0x806 attribute that was already part of the attributes being read over SCSI. There is value in exposing this field because, aside from the lengthier serial number, the barcode is the 6/8-char ID conventionally used in tape libraries to uniquely identify cartridges. 

Notably, when a tape is formatted for LTFS, LTFS officially uses a 6-alphanumeric-character volume name, sometimes called VOLSER, that will be encoded to the barcode 0x806 attribute. This is shown in the HPE LTFS driver code: https://github.com/nix-community/hpe-ltfs/blob/f909474d71deb0e6a7abc71fd47c16a78b9c1eb0/ltfs/src/libltfs/tape.c#L2795
https://github.com/nix-community/hpe-ltfs/blob/f909474d71deb0e6a7abc71fd47c16a78b9c1eb0/ltfs/src/libltfs/tape_ops.h#L888-L904

In this PR, `README.md` is also updated to reflect real-world output from the program that shows the barcode. The sample output was executed on a LTO-6 drive. But I don't mind if the maintainer decides to keep the README with the prior LTO-2 example.

The PR also includes a housekeeping update to the Go dependencies. I have tested compilation and actual use, but only on SAS LTO-6 drives.